### PR TITLE
New: allow user defined sa/cr/crb to take precedence (fixes #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,27 @@
 -f, --force
     : force delete the CRD and CR instances without allowing the controller to clean up children (Default false)
 ```
+
+## Ensure Exist Resources
+
+Some resources created by this job are considered `ensure exist`. That means
+if they have been created/modified already, the install job wont replace whats
+already there. If you would like to re-install RazeeDeploy on a cluster completely
+from scratch, you must first delete these resources:
+
+1. PreReqs: (all installs)
+  - ServiceAccount: `razeedeploy-sa`
+  - ClusterRole: `razeedeploy-admin-cr`
+  - ClusterRoleBinding: `razeedeploy-rb`
+1. Watch-Keeper Config: (only when installing watch-keeper)
+  - ServiceAccount: `watch-keeper-sa`
+  - ClusterRole: `cluster-reader`
+  - ClusterRoleBinding: `watch-keeper-rb`
+  - ConfigMap: `watch-keeper-config`
+  - Secret: `watch-keeper-secret`
+  - ConfigMap: `watch-keeper-limit-poll`
+  - ConfigMap: `watch-keeper-non-namespaced`
+  - NetworkPolicy: `watch-keeper-deny-ingress`
+1. ClusterSubscription Config: (only when installing clustersubscription)
+  - ConfigMap: `clustersubscription`
+  - Secret: `clustersubscription`

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ if they have been created/modified already, the install job wont replace whats
 already there. If you would like to re-install RazeeDeploy on a cluster completely
 from scratch, you must first delete these resources:
 
-1. PreReqs: (all installs)
+- PreReqs: (all installs)
   - ServiceAccount: `razeedeploy-sa`
   - ClusterRole: `razeedeploy-admin-cr`
   - ClusterRoleBinding: `razeedeploy-rb`
-1. Watch-Keeper Config: (only when installing watch-keeper)
+- Watch-Keeper Config: (only when installing watch-keeper)
   - ServiceAccount: `watch-keeper-sa`
   - ClusterRole: `cluster-reader`
   - ClusterRoleBinding: `watch-keeper-rb`
@@ -85,6 +85,6 @@ from scratch, you must first delete these resources:
   - ConfigMap: `watch-keeper-limit-poll`
   - ConfigMap: `watch-keeper-non-namespaced`
   - NetworkPolicy: `watch-keeper-deny-ingress`
-1. ClusterSubscription Config: (only when installing clustersubscription)
+- ClusterSubscription Config: (only when installing clustersubscription)
   - ConfigMap: `clustersubscription`
   - Secret: `clustersubscription`

--- a/src/install.js
+++ b/src/install.js
@@ -87,7 +87,7 @@ async function main() {
   try {
     log.info('=========== Installing Prerequisites ===========');
     let preReqsJson = await readYaml('./src/resources/preReqs.yaml', { desired_namespace: argvNamespace });
-    await decomposeFile(preReqsJson);
+    await decomposeFile(preReqsJson, 'ensureExists');
 
     let resourceUris = Object.values(resourcesObj);
     let resources = Object.keys(resourcesObj);


### PR DESCRIPTION
ensure exist will make sure not to replace the sa, cr, and crb if it has already been created by a user.