### PR TITLE
Fix: allow for unique subscription url or use rdurl.origin (fixes #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
     : install clustersubscription at a specific version (Default 'latest')
 --rd-url, --razeedash-url=''
     : url that watch-keeper should post data to
+--rd-api, --razeedash-api=''
+    : api url that clustersubscription should subscribe to (default '--razeedash-url.origin')
 --rd-org-key, --razeedash-org-key=''
     : org key that watch-keeper will use to authenticate with razeedash-url
 --rd-tags, --razeedash-tags=''


### PR DESCRIPTION
ClusterSubscription needs just the base razeedash api url, while watch-keeper uses the razeedash api url with `/api/v2`. This change will allow the user to either specify a custom rd-api url, or will default to using the base/origin url that the watch-keeper is using. ie. the razeedash-url for watch-keeper could be `https://app.razee.io/api/v2` and the base/origin of that, for clustersubscription, would be `https://app.razee.io`.