### PR TITLE
Breaking: allow user to specify non razee-io org

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -40,7 +40,7 @@ async function main() {
 -n, --namespace=''
     : namespace to populate razeedeploy resources into (Default 'razeedeploy')
 -s, --file-source=''
-    : url that razeedeploy-job should source razeedeploy resource files from (Default 'https://github.com')
+    : url that razeedeploy-job should source razeedeploy resource files from (Default 'https://github.com/razee-io')
 --wk, --watch-keeper=''
     : install watch-keeper at a specific version (Default 'latest')
 --cs, --clustersubscription=''
@@ -71,7 +71,7 @@ async function main() {
     return;
   }
 
-  let fileSource = typeof (argv.s || argv['file-source']) === 'string' ? argv.s || argv['file-source'] : 'https://github.com';
+  let fileSource = typeof (argv.s || argv['file-source']) === 'string' ? argv.s || argv['file-source'] : 'https://github.com/razee-io';
   if (!validUrl.isUri(fileSource)) {
     return log.error(`'${fileSource}' not a valid source url.`);
   } else if (fileSource.endsWith('/')) {
@@ -97,14 +97,14 @@ async function main() {
   let autoUpdateArray = [];
 
   let resourcesObj = {
-    'watch-keeper': { install: argv.wk || argv['watch-keeper'], uri: `${fileSource}/razee-io/watch-keeper/releases/{{install_version}}/resource.yaml` },
-    'clustersubscription': { install: argv.cs || argv['clustersubscription'], uri: `${fileSource}/razee-io/ClusterSubscription/releases/{{install_version}}/resource.yaml` },
-    'remoteresource': { install: argv.rr || argv['remoteresource'], uri: `${fileSource}/razee-io/RemoteResource/releases/{{install_version}}/resource.yaml` },
-    'remoteresources3': { install: argv.rrs3 || argv['remoteresources3'], uri: `${fileSource}/razee-io/RemoteResourceS3/releases/{{install_version}}/resource.yaml` },
-    'remoteresources3decrypt': { install: argv.rrs3d || argv['remoteresources3decrypt'], uri: `${fileSource}/razee-io/RemoteResourceS3Decrypt/releases/{{install_version}}/resource.yaml` },
-    'mustachetemplate': { install: argv.mtp || argv['mustachetemplate'], uri: `${fileSource}/razee-io/MustacheTemplate/releases/{{install_version}}/resource.yaml` },
-    'featureflagsetld': { install: argv.ffsld || argv['featureflagsetld'], uri: `${fileSource}/razee-io/FeatureFlagSetLD/releases/{{install_version}}/resource.yaml` },
-    'managedset': { install: argv.ms || argv['managedset'], uri: `${fileSource}/razee-io/ManagedSet/releases/{{install_version}}/resource.yaml` }
+    'watch-keeper': { install: argv.wk || argv['watch-keeper'], uri: `${fileSource}/watch-keeper/releases/{{install_version}}/resource.yaml` },
+    'clustersubscription': { install: argv.cs || argv['clustersubscription'], uri: `${fileSource}/ClusterSubscription/releases/{{install_version}}/resource.yaml` },
+    'remoteresource': { install: argv.rr || argv['remoteresource'], uri: `${fileSource}/RemoteResource/releases/{{install_version}}/resource.yaml` },
+    'remoteresources3': { install: argv.rrs3 || argv['remoteresources3'], uri: `${fileSource}/RemoteResourceS3/releases/{{install_version}}/resource.yaml` },
+    'remoteresources3decrypt': { install: argv.rrs3d || argv['remoteresources3decrypt'], uri: `${fileSource}/RemoteResourceS3Decrypt/releases/{{install_version}}/resource.yaml` },
+    'mustachetemplate': { install: argv.mtp || argv['mustachetemplate'], uri: `${fileSource}/MustacheTemplate/releases/{{install_version}}/resource.yaml` },
+    'featureflagsetld': { install: argv.ffsld || argv['featureflagsetld'], uri: `${fileSource}/FeatureFlagSetLD/releases/{{install_version}}/resource.yaml` },
+    'managedset': { install: argv.ms || argv['managedset'], uri: `${fileSource}/ManagedSet/releases/{{install_version}}/resource.yaml` }
   };
 
   try {

--- a/src/remove.js
+++ b/src/remove.js
@@ -40,7 +40,7 @@ async function main() {
 --dn, --delete-namespace=''
     : include namespace as a resource to delete (Default false)
 -s, --file-source=''
-    : url that razeedeploy-job should source razeedeploy resource files from (Default 'https://github.com')
+    : url that razeedeploy-job should source razeedeploy resource files from (Default 'https://github.com/razee-io')
 -t, --timeout
     : time (minutes) before failing to delete CRD (Default 5)
 -a, --attempts
@@ -51,7 +51,7 @@ async function main() {
     return;
   }
 
-  let fileSource = typeof (argv.s || argv['file-source']) === 'string' ? argv.s || argv['file-source'] : 'https://github.com';
+  let fileSource = typeof (argv.s || argv['file-source']) === 'string' ? argv.s || argv['file-source'] : 'https://github.com/razee-io';
   if (!validUrl.isUri(fileSource)) {
     return log.error(`'${fileSource}' not a valid source url.`);
   } else if (fileSource.endsWith('/')) {
@@ -59,14 +59,14 @@ async function main() {
   }
 
   let resourcesObj = {
-    'watch-keeper': { remove: argv.wk || argv['watch-keeper'], uri: `${fileSource}/razee-io/watch-keeper/releases/{{install_version}}/resource.yaml` },
-    'clustersubscription': { install: argv.cs || argv['clustersubscription'], uri: `${fileSource}/razee-io/ClusterSubscription/releases/{{install_version}}/resource.yaml` },
-    'remoteresource': { remove: argv.rr || argv['remoteresource'], uri: `${fileSource}/razee-io/RemoteResource/releases/{{install_version}}/resource.yaml` },
-    'remoteresources3': { remove: argv.rrs3 || argv['remoteresources3'], uri: `${fileSource}/razee-io/RemoteResourceS3/releases/{{install_version}}/resource.yaml` },
-    'remoteresources3decrypt': { remove: argv.rrs3d || argv['remoteresources3decrypt'], uri: `${fileSource}/razee-io/RemoteResourceS3Decrypt/releases/{{install_version}}/resource.yaml` },
-    'mustachetemplate': { remove: argv.mtp || argv['mustachetemplate'], uri: `${fileSource}/razee-io/MustacheTemplate/releases/{{install_version}}/resource.yaml` },
-    'featureflagsetld': { remove: argv.ffsld || argv['featureflagsetld'], uri: `${fileSource}/razee-io/FeatureFlagSetLD/releases/{{install_version}}/resource.yaml` },
-    'managedset': { remove: argv.ms || argv['managedset'], uri: `${fileSource}/razee-io/ManagedSet/releases/{{install_version}}/resource.yaml` }
+    'watch-keeper': { remove: argv.wk || argv['watch-keeper'], uri: `${fileSource}/watch-keeper/releases/{{install_version}}/resource.yaml` },
+    'clustersubscription': { install: argv.cs || argv['clustersubscription'], uri: `${fileSource}/ClusterSubscription/releases/{{install_version}}/resource.yaml` },
+    'remoteresource': { remove: argv.rr || argv['remoteresource'], uri: `${fileSource}/RemoteResource/releases/{{install_version}}/resource.yaml` },
+    'remoteresources3': { remove: argv.rrs3 || argv['remoteresources3'], uri: `${fileSource}/RemoteResourceS3/releases/{{install_version}}/resource.yaml` },
+    'remoteresources3decrypt': { remove: argv.rrs3d || argv['remoteresources3decrypt'], uri: `${fileSource}/RemoteResourceS3Decrypt/releases/{{install_version}}/resource.yaml` },
+    'mustachetemplate': { remove: argv.mtp || argv['mustachetemplate'], uri: `${fileSource}/MustacheTemplate/releases/{{install_version}}/resource.yaml` },
+    'featureflagsetld': { remove: argv.ffsld || argv['featureflagsetld'], uri: `${fileSource}/FeatureFlagSetLD/releases/{{install_version}}/resource.yaml` },
+    'managedset': { remove: argv.ms || argv['managedset'], uri: `${fileSource}/ManagedSet/releases/{{install_version}}/resource.yaml` }
   };
 
   let dltNamespace = typeof (argv.dn || argv['delete-namespace']) === 'boolean' ? argv.dn || argv['delete-namespace'] : false;


### PR DESCRIPTION
if a user wants to use github releases to store their own version of yaml, allow them to specify that in the file source url. default to `https://github.com/razee-io`