### PR TITLE
feat: allow optional uuid template on job name

### DIFF
--- a/kubernetes/job/resource.yaml
+++ b/kubernetes/job/resource.yaml
@@ -57,7 +57,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: razeedeploy-job
+  name: "razeedeploy-job{{{ UUID }}}"
   namespace: "{{{ NAMESPACE }}}"
 spec:
   template:
@@ -68,7 +68,7 @@ spec:
         runAsGroup: <%NODE_GROUP_ID%>
         fsGroup: <%NODE_GROUP_ID%>
       containers:
-      - name: razeedeploy-job
+      - name: "razeedeploy-job{{{ UUID }}}"
         image: "quay.io/razee/razeedeploy-delta:<%TRAVIS_TAG%>"
         command: ["./bin/razeedeploy-delta", "{{ COMMAND }}", "--namespace={{{ NAMESPACE }}}"]
         args: {{ ARGS_ARRAY }}


### PR DESCRIPTION
if a uuid is defined in the template view, it will append it to the job name. If it is not defined, it will keep the same name it always has used `razeedeploy-job`.

This will be useful, so users dont have to delete the old job if they want to run the job again.