### PR TITLE
fix: wk needs 'use' verb to run in openshift clusters

### DIFF
--- a/src/resources/wkConfig.yaml
+++ b/src/resources/wkConfig.yaml
@@ -32,10 +32,10 @@ rules:
   - '*'
   resources:
   - '*'
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "use"]
 - nonResourceURLs:
   - '*'
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "use"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
in order to run as user 1000 in openshift clusters, the watch-keeper-sa needs the 'use' verb.