### PR TITLE
do not install webhook implicitly

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -195,12 +195,6 @@ async function main() {
       await decomposeFile(ridConfigJson, applyMode);
     }
 
-    if (!installAll && (objectPath.get(resourcesObj, 'remoteresource.install') || objectPath.get(resourcesObj, 'mustachetemplate.install'))) {
-      if (!objectPath.get(resourcesObj, "impersonationwebhook.install")) {
-        objectPath.set(resourcesObj, "impersonationwebhook.install", true);
-      }
-    }
-
     let webhookCert = extractCustomCert(argv['iw-cert']);
 
     for (var i = 0; i < resourceUris.length; i++) {

--- a/src/install.js
+++ b/src/install.js
@@ -71,7 +71,7 @@ async function main() {
 --mtp, --mustachetemplate=''
     : install mustachetemplate at a specific version (Default 'latest')
 --iw, --impersonationwebhook=''
-    : install impersonation webhook at a specific version (Default 'latest'). When remote resource controller and/or mustache template controller are installed, this webhook will be installed even if this flag is not set
+    : install impersonation webhook at a specific version (Default 'latest').
 --iw-cert
     : base64 encoded JSON object of webhook certificate in PEM format. The corresponding keys for CA cert, server cert, and server key are: 'ca', 'server', 'key'. If CA cert is missing, the server cert will be used as CA cert. Each key holds the base64 encoded representation of the corresponding PEM. And the whole JSON file is encoded in base64
 --ffsld, --featureflagsetld=''


### PR DESCRIPTION
Do not install impersonation webhook by default when remote resource or mustache template are installed. Must use flags explicitly to install the webhook.