### PR TITLE
Automatically attempt cleanup of deprecated razee operators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1348,9 +1348,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001486",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
-      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
+      "version": "1.0.30001487",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
+      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
       "dev": true,
       "funding": [
         {
@@ -1798,9 +1798,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.389",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.389.tgz",
-      "integrity": "sha512-WDgWUOK8ROR7sDFyYmxCUOoDc50lPgYAHAHwnnD1iN3SKO/mpqftb9iIPiEkMKmqYdkrR0j3N/O+YB/U7lSxwg==",
+      "version": "1.4.397",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.397.tgz",
+      "integrity": "sha512-jwnPxhh350Q/aMatQia31KAIQdhEsYS0fFZ0BQQlN9tfvOEwShu6ZNwI4kL/xBabjcB/nTy6lSt17kNIluJZ8Q==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2463,13 +2463,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -3014,9 +3015,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -3768,11 +3769,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.1.tgz",
+      "integrity": "sha512-Tenl5QPpgozlOGBiveNYHg2f6y+VpxsXRoIHFUVJuSmTonXRAE6q9b8Mp/O46762/2AlW4ye4Nkyvx0fgWDKbw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
@@ -4036,12 +4037,21 @@
       }
     },
     "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.1.0.tgz",
+      "integrity": "sha512-w1qd368vtrwttm1PRJWPW1QHlbmHrVDGs1eBH/jZvRPUFS4MNXV9Q33EQdjOdeAxZ7O8+3wM7zxztm2nfUSyKw==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^2.0.0"
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
       }
     },
     "node_modules/nock": {
@@ -5658,6 +5668,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -7224,9 +7242,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001486",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
-      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
+      "version": "1.0.30001487",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
+      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
       "dev": true
     },
     "caseless": {
@@ -7540,9 +7558,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.389",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.389.tgz",
-      "integrity": "sha512-WDgWUOK8ROR7sDFyYmxCUOoDc50lPgYAHAHwnnD1iN3SKO/mpqftb9iIPiEkMKmqYdkrR0j3N/O+YB/U7lSxwg==",
+      "version": "1.4.397",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.397.tgz",
+      "integrity": "sha512-jwnPxhh350Q/aMatQia31KAIQdhEsYS0fFZ0BQQlN9tfvOEwShu6ZNwI4kL/xBabjcB/nTy6lSt17kNIluJZ8Q==",
       "dev": true
     },
     "emoji-regex": {
@@ -8029,13 +8047,14 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       }
     },
@@ -8416,9 +8435,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -8966,9 +8985,9 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.1.tgz",
+      "integrity": "sha512-Tenl5QPpgozlOGBiveNYHg2f6y+VpxsXRoIHFUVJuSmTonXRAE6q9b8Mp/O46762/2AlW4ye4Nkyvx0fgWDKbw=="
     },
     "minizlib": {
       "version": "2.1.2",
@@ -9184,12 +9203,23 @@
           }
         },
         "@sinonjs/fake-timers": {
-          "version": "10.0.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-          "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.1.0.tgz",
+          "integrity": "sha512-w1qd368vtrwttm1PRJWPW1QHlbmHrVDGs1eBH/jZvRPUFS4MNXV9Q33EQdjOdeAxZ7O8+3wM7zxztm2nfUSyKw==",
           "dev": true,
           "requires": {
-            "@sinonjs/commons": "^2.0.0"
+            "@sinonjs/commons": "^3.0.0"
+          },
+          "dependencies": {
+            "@sinonjs/commons": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+              "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+              "dev": true,
+              "requires": {
+                "type-detect": "4.0.8"
+              }
+            }
           }
         }
       }
@@ -10379,6 +10409,11 @@
         "yallist": "^4.0.0"
       },
       "dependencies": {
+        "minipass": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+          "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",

--- a/src/install.js
+++ b/src/install.js
@@ -168,7 +168,6 @@ async function main() {
     'remoteresources3decrypt': { install: argv.rrs3d || argv['remoteresources3decrypt'], uri: `${fileSource}/RemoteResourceS3Decrypt/${filePath}` },
     'mustachetemplate': { install: argv.mtp || argv['mustachetemplate'], uri: `${fileSource}/MustacheTemplate/${filePath}` },
     'featureflagsetld': { install: argv.ffsld || argv['featureflagsetld'], uri: `${fileSource}/FeatureFlagSetLD/${filePath}` },
-    'encryptedresource': { install: argv.er || argv['encryptedresource'], uri: `${fileSource}/EncryptedResource/${filePath}` },
     'managedset': { install: argv.ms || argv['managedset'], uri: `${fileSource}/ManagedSet/${filePath}` },
     'impersonationwebhook': { install: argv.iw || argv['impersonationwebhook'], uri: `${fileSource}/ImpersonationWebhook/${filePath}` }
   };

--- a/src/install.js
+++ b/src/install.js
@@ -30,7 +30,7 @@ const axios = require('axios');
 const handlebars = require('handlebars');
 const forge = require('node-forge');
 
-const { deprecatedResourcesObj, removeDeprecatedResources } = require('./remove');
+const { purgeDeprecatedResources, removeDeprecatedResources } = require('./remove');
 
 var success = true;
 const argvNamespace = typeof (argv.n || argv.namespace) === 'string' ? argv.n || argv.namespace : 'razeedeploy';
@@ -173,11 +173,7 @@ async function main() {
   };
 
   // Handle deprecated resources
-  for( const resourceName of Object.getOwnPropertyNames( resourcesObj ) ) {
-    if( Object.hasOwn( deprecatedResourcesObj, resourceName ) ) {
-      delete resourcesObj[ resourceName ];
-    }
-  }
+  purgeDeprecatedResources( resourcesObj );
   await removeDeprecatedResources( argvNamespace ); // No force, default retries and timeouts
 
   try {

--- a/src/remove.js
+++ b/src/remove.js
@@ -27,6 +27,9 @@ const fs = require('fs-extra');
 const axios = require('axios');
 const handlebars = require('handlebars');
 
+var success = true;
+const argvNamespace = typeof (argv.n || argv.namespace) === 'string' ? argv.n || argv.namespace : 'razeedeploy';
+
 // Track deprecated resources that may be unable to retrieve YAML due to removal
 const deprecatedResourcesObj = {
   'encryptedresource': {
@@ -44,6 +47,7 @@ const deprecatedResourcesObj = {
           kind: Deployment
           metadata:
             name: encryptedresource-controller
+            namespace: ${argvNamespace}
         - apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           metadata:
@@ -51,9 +55,6 @@ const deprecatedResourcesObj = {
     `
   },
 };
-
-var success = true;
-const argvNamespace = typeof (argv.n || argv.namespace) === 'string' ? argv.n || argv.namespace : 'razeedeploy';
 
 async function main() {
   if (argv.h || argv.help) {

--- a/src/remove.js
+++ b/src/remove.js
@@ -131,15 +131,8 @@ async function main() {
   let timeout = typeof (argv.t || argv.timeout) === 'number' ? argv.t || argv.timeout : 5;
 
   // Handle deprecated resources
-  for( const resourceName of Object.getOwnPropertyNames( resourcesObj ) ) {
-    if( Object.hasOwn( deprecatedResourcesObj, resourceName ) ) {
-      delete resourcesObj[ resourceName ];
-    }
-  }
+  purgeDeprecatedResources( resourcesObj );
   await removeDeprecatedResources( argvNamespace, force, attempts, timeout );
-
-  console.log( `PLC aborting!` );
-  process.exit(9);
 
   try {
     let resourceUris = Object.values(resourcesObj);
@@ -184,6 +177,14 @@ async function main() {
     log.error(e);
   }
 }
+
+function purgeDeprecatedResources( resourcesObj ) {
+  for( const resourceName of Object.getOwnPropertyNames( deprecatedResourcesObj ) ) {
+    if( Object.hasOwn( resourcesObj, resourceName ) ) {
+      delete resourcesObj[ resourceName ];
+    }
+  }
+};
 
 // Attempt to remove any deprecated resources
 async function removeDeprecatedResources( namespace, force, attempts, timeout ) {
@@ -417,5 +418,5 @@ async function run() {
 module.exports = {
   run,
   removeDeprecatedResources,
-  deprecatedResourcesObj
+  purgeDeprecatedResources
 };

--- a/src/update.js
+++ b/src/update.js
@@ -49,7 +49,6 @@ async function main() {
   };
 
   // Handle deprecated resources
-  // Handle deprecated resources
   purgeDeprecatedResources( resourcesObj );
   await removeDeprecatedResources( argvNamespace ); // No force, default retries and timeouts
 

--- a/src/update.js
+++ b/src/update.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 IBM Corp. All Rights Reserved.
+ * Copyright 2022, 2023 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ const clone = require('clone');
 const objectPath = require('object-path');
 const handlebars = require('handlebars');
 
+const { deprecatedResourcesObj, removeDeprecatedResources } = require('./remove');
+
 var success = true;
 const argvNamespace = typeof (argv.n || argv.namespace) === 'string' ? argv.n || argv.namespace : 'razeedeploy';
 
@@ -44,8 +46,15 @@ async function main() {
     'clustersubscription': { install: argv.cs || argv['clustersubscription'], uri: `${fileSource}/ClusterSubscription/${filePath}` },
     'remoteresource': { install: argv.rr || argv['remoteresource'], uri: `${fileSource}/RemoteResource/${filePath}` },
     'mustachetemplate': { install: argv.mtp || argv['mustachetemplate'], uri: `${fileSource}/MustacheTemplate/${filePath}` },
-    'encryptedresource': { install: argv.er || argv['encryptedresource'], uri: `${fileSource}/EncryptedResource/${filePath}` }
   };
+
+  // Handle deprecated resources
+  for( const resourceName of Object.getOwnPropertyNames( resourcesObj ) ) {
+    if( Object.hasOwn( deprecatedResourcesObj, resourceName ) ) {
+      delete resourcesObj[ resourceName ];
+    }
+  }
+  await removeDeprecatedResources( argvNamespace ); // No force, default retries and timeouts
 
   let resourceUris = Object.values(resourcesObj);
   let installAll = resourceUris.reduce((shouldInstallAll, currentValue) => {
@@ -59,7 +68,6 @@ async function main() {
       await decomposeFile(file);
     }
   }
-  
 }
 
 async function download(resourceUriObj) {
@@ -77,7 +85,6 @@ async function download(resourceUriObj) {
     log.warn(`Failed to download ${uri}.. defaulting to ${latestUri}`);
     return await axios.get(latestUri);
   }
-
 }
 
 function readYaml(file) {
@@ -211,7 +218,6 @@ async function run() {
     log.error(error);
     process.exit(1);
   }
-
 }
 
 module.exports = {

--- a/src/update.js
+++ b/src/update.js
@@ -25,7 +25,7 @@ const clone = require('clone');
 const objectPath = require('object-path');
 const handlebars = require('handlebars');
 
-const { deprecatedResourcesObj, removeDeprecatedResources } = require('./remove');
+const { purgeDeprecatedResources, removeDeprecatedResources } = require('./remove');
 
 var success = true;
 const argvNamespace = typeof (argv.n || argv.namespace) === 'string' ? argv.n || argv.namespace : 'razeedeploy';
@@ -49,11 +49,8 @@ async function main() {
   };
 
   // Handle deprecated resources
-  for( const resourceName of Object.getOwnPropertyNames( resourcesObj ) ) {
-    if( Object.hasOwn( deprecatedResourcesObj, resourceName ) ) {
-      delete resourcesObj[ resourceName ];
-    }
-  }
+  // Handle deprecated resources
+  purgeDeprecatedResources( resourcesObj );
   await removeDeprecatedResources( argvNamespace ); // No force, default retries and timeouts
 
   let resourceUris = Object.values(resourcesObj);


### PR DESCRIPTION
Automatically attempt cleanup of deprecated razee operators on install, update, and remove operations

If CRD for the deprecated operator is not removable (in use), skip removing the deprecated operator and log details